### PR TITLE
Update build.gradle to support SDK 11

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "23.0.2"
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 11
         targetSdkVersion 23
         versionCode 1
         versionName "1.0.1"


### PR DESCRIPTION
SDK 11 can be supported as both appcompat-v7 and support-v4 being used. So, no issue to support old versions.