### PR TITLE
Removed the custom pending transition

### DIFF
--- a/library/src/main/java/com/github/fcannizzaro/materialstepper/style/BaseStyle.java
+++ b/library/src/main/java/com/github/fcannizzaro/materialstepper/style/BaseStyle.java
@@ -92,8 +92,6 @@ public class BaseStyle extends AppCompatActivity implements Stepable {
 
     protected void applyTheme() {
 
-        overridePendingTransition(R.anim.in_from_bottom, R.anim.out_to_bottom);
-
         findColors();
 
         if (getSupportActionBar() != null) {


### PR DESCRIPTION
Hey,

good library thanks!

I want to use the default android pending transition in my apps, but since there is already a custom transition defined in the library, i have to override it in every app. In my opinion we should remove the custom transition in the library and let the developers decide.