### PR TITLE
Update Android Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.0.0'
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 11

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         applicationId "com.fcannizzaro.materialstepper"


### PR DESCRIPTION
[Android Studio 2.0 is now stable](http://tools.android.com/recent/androidstudio20andemulator2511areavailableinthestablebetaanddevchannels)

The Android Gradle plug-in and build tools have also been updated.