### PR TITLE
ViewPager swipe disabling bug fix

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 11
         targetSdkVersion 23
         versionCode 3
-        versionName "1.0.9"
+        versionName "1.1.0"
     }
     buildTypes {
         release {

--- a/library/src/main/java/com/github/fcannizzaro/materialstepper/AbstractStep.java
+++ b/library/src/main/java/com/github/fcannizzaro/materialstepper/AbstractStep.java
@@ -19,7 +19,7 @@ public abstract class AbstractStep extends Fragment implements Nextable {
 
     @Override
     public String optional() {
-        return getString(R.string.ms_optional);
+        return isAdded() ? getString(R.string.ms_optional) : "";
     }
 
     public abstract String name();

--- a/library/src/main/java/com/github/fcannizzaro/materialstepper/style/BasePager.java
+++ b/library/src/main/java/com/github/fcannizzaro/materialstepper/style/BasePager.java
@@ -1,8 +1,6 @@
 package com.github.fcannizzaro.materialstepper.style;
 
 import android.support.v4.view.ViewPager;
-import android.view.MotionEvent;
-import android.view.View;
 
 import com.github.fcannizzaro.materialstepper.AbstractStep;
 import com.github.fcannizzaro.materialstepper.R;
@@ -26,12 +24,6 @@ public class BasePager extends BaseStyle {
         mPager = (ViewPager) findViewById(R.id.stepPager);
         assert mPager != null;
         mPager.setAdapter(mPagerAdapter);
-        mPager.setOnTouchListener(new View.OnTouchListener() {
-            @Override
-            public boolean onTouch(View view, MotionEvent motionEvent) {
-                return true;
-            }
-        });
         mSteps.get(0).onStepVisible();
         mPager.addOnPageChangeListener(new PageChangeAdapter() {
             @Override

--- a/library/src/main/java/com/github/fcannizzaro/materialstepper/widget/LockedViewPager.java
+++ b/library/src/main/java/com/github/fcannizzaro/materialstepper/widget/LockedViewPager.java
@@ -1,0 +1,33 @@
+package com.github.fcannizzaro.materialstepper.widget;
+
+import android.content.Context;
+import android.support.v4.view.ViewPager;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+
+/**
+ * Non-swipeable ViewPager
+ * Created by alashov on 07/05/16.
+ */
+public class LockedViewPager extends ViewPager {
+
+    public LockedViewPager(Context context) {
+        super(context);
+    }
+
+    public LockedViewPager(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent event) {
+        // Disable swipe
+        return false;
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        // Disable swipe
+        return false;
+    }
+}

--- a/library/src/main/res/layout/style_dots.xml
+++ b/library/src/main/res/layout/style_dots.xml
@@ -4,7 +4,7 @@
     android:layout_height="match_parent"
     android:background="#e0e0e0">
 
-    <android.support.v4.view.ViewPager
+    <com.github.fcannizzaro.materialstepper.widget.LockedViewPager
         android:id="@+id/stepPager"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/library/src/main/res/layout/style_horizontal_tabs.xml
+++ b/library/src/main/res/layout/style_horizontal_tabs.xml
@@ -38,7 +38,7 @@
 
         </android.support.v7.widget.CardView>
 
-        <android.support.v4.view.ViewPager
+        <com.github.fcannizzaro.materialstepper.widget.LockedViewPager
             android:id="@+id/stepPager"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />

--- a/library/src/main/res/layout/style_progress.xml
+++ b/library/src/main/res/layout/style_progress.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:background="#e0e0e0">
 
-    <android.support.v4.view.ViewPager
+    <com.github.fcannizzaro.materialstepper.widget.LockedViewPager
         android:id="@+id/stepPager"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/library/src/main/res/layout/style_text.xml
+++ b/library/src/main/res/layout/style_text.xml
@@ -52,7 +52,7 @@
 
         </ViewSwitcher>
 
-        <android.support.v4.view.ViewPager
+        <com.github.fcannizzaro.materialstepper.widget.LockedViewPager
             android:id="@+id/stepPager"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />


### PR DESCRIPTION
Disabling viewPager's swipe just by adding onTouch listener does not work properly. It can be swipeable by little bit flinging finger.

Fixed by creating custom viewPager.

About `getString()` see [here](https://github.com/fcannizzaro/material-stepper/issues/25#issuecomment-217609330).

http://stackoverflow.com/a/13392198/2897341